### PR TITLE
Add material-theme CSS via custom Suite8 theme

### DIFF
--- a/public/legacy/custom/themes/suite8/css/material-theme.css
+++ b/public/legacy/custom/themes/suite8/css/material-theme.css
@@ -1,0 +1,31 @@
+/* Material Design theme overrides */
+button {
+  border-radius: 0.25rem;
+  box-shadow: 0 1px 2px rgba(0,0,0,0.14), 0 1px 3px rgba(0,0,0,0.12);
+  transition: background-color 0.3s ease, box-shadow 0.3s ease;
+}
+button:hover, button:active {
+  box-shadow: 0 3px 4px rgba(0,0,0,0.14), 0 1px 8px rgba(0,0,0,0.12);
+}
+button:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 3px #85b7ff;
+}
+input, .login-form select {
+  border-radius: 0.25rem;
+}
+.pagination-button {
+  border-radius: 0.25rem;
+}
+.alerts-button { background-color: #d93025; }
+.alerts-button:hover, .alerts-button:active { background-color: #dc443a; }
+.quickcreate-button { background-color: #1a73e8; color: #fff; }
+.quickcreate-button:hover, .quickcreate-button:active { background-color: #3081ea; }
+.favourites-button { background-color: #f9ab00; }
+.favourites-button:hover, .favourites-button:active { background-color: #f9b319; }
+.action-button { background-color: #1a73e8; }
+.action-button:hover { background-color: #3081ea; }
+.settings-button { background-color: #5f6368; }
+.settings-button:hover { background-color: #8f9195; }
+.modal-button-save { background-color: #1a73e8; }
+.modal-button-cancel { background-color: #5f6368; }

--- a/public/legacy/custom/themes/suite8/tpls/_head.tpl
+++ b/public/legacy/custom/themes/suite8/tpls/_head.tpl
@@ -1,0 +1,83 @@
+{*
+/**
+ *
+ * SugarCRM Community Edition is a customer relationship management program developed by
+ * SugarCRM, Inc. Copyright (C) 2004-2013 SugarCRM Inc.
+ *
+ * SuiteCRM is an extension to SugarCRM Community Edition developed by SalesAgility Ltd.
+ * Copyright (C) 2011 - 2018 SalesAgility Ltd.
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Affero General Public License version 3 as published by the
+ * Free Software Foundation with the addition of the following permission added
+ * to Section 15 as permitted in Section 7(a): FOR ANY PART OF THE COVERED WORK
+ * IN WHICH THE COPYRIGHT IS OWNED BY SUGARCRM, SUGARCRM DISCLAIMS THE WARRANTY
+ * OF NON INFRINGEMENT OF THIRD PARTY RIGHTS.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License along with
+ * this program; if not, see http://www.gnu.org/licenses or write to the Free
+ * Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301 USA.
+ *
+ * You can contact SugarCRM, Inc. headquarters at 10050 North Wolfe Road,
+ * SW2-130, Cupertino, CA 95014, USA. or at email address contact@sugarcrm.com.
+ *
+ * The interactive user interfaces in modified source and object code versions
+ * of this program must display Appropriate Legal Notices, as required under
+ * Section 5 of the GNU Affero General Public License version 3.
+ *
+ * In accordance with Section 7(b) of the GNU Affero General Public License version 3,
+ * these Appropriate Legal Notices must retain the display of the "Powered by
+ * SugarCRM" logo and "Supercharged by SuiteCRM" logo. If the display of the logos is not
+ * reasonably feasible for technical reasons, the Appropriate Legal Notices must
+ * display the words "Powered by SugarCRM" and "Supercharged by SuiteCRM".
+ */
+*}
+<!DOCTYPE html>
+<html {$langHeader}>
+<head>
+    <link rel="SHORTCUT ICON" href="{$FAVICON_URL}">
+    <meta http-equiv="Content-Type" content="text/html; charset={$APP.LBL_CHARSET}">
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="user-scalable=no, initial-scale=1, maximum-scale=1, minimum-scale=1" />
+    <!-- Bootstrap -->
+    <link href="themes/suite8/css/normalize.css" rel="stylesheet" type="text/css"/>
+    <link href='themes/suite8/css/fonts.css' rel='stylesheet' type='text/css'>
+    <link href="themes/suite8/css/grid.css" rel="stylesheet" type="text/css"/>
+    <link href="themes/suite8/css/footable.core.css" rel="stylesheet" type="text/css"/>
+    <title>{if $BROWSER_TITLE}{$BROWSER_TITLE}{else}{$APP.LBL_BROWSER_TITLE}{/if}</title>
+
+    <!-- HTML5 shim and Respond.js for IE8 support of HTML5 elements and media queries -->
+    <!-- WARNING: Respond.js doesn't work if you view the page via file:// -->
+    <!--[if lt IE 9]>
+    <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
+    <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
+    <![endif]-->
+    {$SUGAR_JS}
+    {literal}
+    <script type="text/javascript">
+        <!--
+        SUGAR.themes.theme_name = '{/literal}{$THEME}{literal}';
+        SUGAR.themes.theme_ie6compat = '{/literal}{$THEME_IE6COMPAT}{literal}';
+        SUGAR.themes.hide_image = '{/literal}{sugar_getimagepath file="hide.gif"}{literal}';
+        SUGAR.themes.show_image = '{/literal}{sugar_getimagepath file="show.gif"}{literal}';
+        SUGAR.themes.loading_image = '{/literal}{sugar_getimagepath file="img_loading.gif"}{literal}';
+
+        if (YAHOO.env.ua)
+            UA = YAHOO.env.ua;
+        -->
+    </script>
+    {/literal}
+    {$SUGAR_CSS}
+    <link rel="stylesheet" href="custom/themes/suite8/css/material-theme.css"/>
+    <link rel="stylesheet" type="text/css" href="themes/suite8/css/colourSelector.php">
+    <script type="text/javascript" src='{sugar_getjspath file="themes/suite8/js/jscolor.js"}'></script>
+    <script type="text/javascript" src='{sugar_getjspath file="cache/include/javascript/sugar_field_grp.js"}'></script>
+    <script type="text/javascript" src='{sugar_getjspath file="vendor/tinymce/tinymce/tinymce.min.js"}'></script>
+</head>


### PR DESCRIPTION
## Summary
- copy `material-theme.css` into upgrade-safe custom theme folder
- include custom CSS from copied `_head.tpl`

## Testing
- `npm run lint` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68485de9e8d88321b70d2e897ef06ad4