### PR TITLE
Fix material-theme path in Suite8 head template

### DIFF
--- a/public/legacy/custom/themes/suite8/tpls/_head.tpl
+++ b/public/legacy/custom/themes/suite8/tpls/_head.tpl
@@ -76,7 +76,7 @@
     {/literal}
     {$SUGAR_CSS}
     
-    <link rel="stylesheet" href="public/legacy/custom/themes/suite8/css/material-theme.css"/>
+    <link rel="stylesheet" href="custom/themes/suite8/css/material-theme.css"/>
     <link rel="stylesheet" type="text/css" href="themes/suite8/css/colourSelector.php">
     <script type="text/javascript" src='{sugar_getjspath file="themes/suite8/js/jscolor.js"}'></script>
     <script type="text/javascript" src='{sugar_getjspath file="cache/include/javascript/sugar_field_grp.js"}'></script>


### PR DESCRIPTION
## Summary
- fix `material-theme.css` link path

## Testing
- `yarn lint` *(fails: Couldn't find node_modules state file)*

------
https://chatgpt.com/codex/tasks/task_e_6848649ce1288321a2e0f7d0c9c1df31