### PR TITLE
Update nav icon color

### DIFF
--- a/public/dist/material-theme.css
+++ b/public/dist/material-theme.css
@@ -154,3 +154,7 @@ a:hover {
   border-radius: 0.25rem;
   box-shadow: 0 1px 3px rgba(60,64,67,0.15);
 }
+
+.nav-item.active .home-nav-link svg {
+  fill: #fff;
+}

--- a/public/legacy/custom/themes/suite8/css/material-theme.css
+++ b/public/legacy/custom/themes/suite8/css/material-theme.css
@@ -154,3 +154,7 @@ a:hover {
   border-radius: 0.25rem;
   box-shadow: 0 1px 3px rgba(60,64,67,0.15);
 }
+
+.nav-item.active .home-nav-link svg {
+  fill: #fff;
+}


### PR DESCRIPTION
## Summary
- set active home nav icon fill to white in built theme CSS

## Testing
- `yarn lint` *(fails: couldn't find node_modules)*
- `npm test` *(fails: Missing script: "test"*)

------
https://chatgpt.com/codex/tasks/task_e_6848c3e8e5a8832195a190e8ecfebf71